### PR TITLE
Add support to storage_blob_host configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ terraform.tfstate
 terraform.tfstate.backup
 .terraform.tfstate.lock.info
 *.tfvars
+
+__azurite_db*
+__blobstorage__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Allow creating public container
+- Add Azurite support
 
 ## [0.5.3] 2024-10-31
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,42 @@ prod:
   principal_id: 71b34410-4c50-451d-b456-95ead1b18cce
 ```
 
+### Azurite
+
+To use Azurite, pass the `storage_blob_host` config key with the Azurite URL (`http://127.0.0.1:10000/devstoreaccount1` by default)
+and the Azurite credentials (`devstoreaccount1` and `Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==` by default).
+
+Example:
+
+```
+dev:
+  service: AzureBlob
+  container: container_name
+  storage_account_name: devstoreaccount1
+  storage_access_key: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+  storage_blob_host: http://127.0.0.1:10000/devstoreaccount1
+```
+
+You'll have to create the container before you can start uploading files.
+You can do so using Azure CLI, Azure Storage Explorer, or by running:
+
+
+```
+bin/rails runner "
+container_name = 'CONTAINER_NAME_REPLACE_ME'
+require %{azure_blob}
+AzureBlob::Client.new(
+account_name: %{devstoreaccount1},
+access_key: %{Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==},
+host: %{http://127.0.0.1:10000/devstoreaccount1},
+container: container_name)
+.tap{|container| container.create_container unless container.get_container_properties.present?}
+.tap{|container| puts 'done!' if container.get_container_properties.present?}"
+```
+
+Replace `CONTAINER_NAME_REPLACE_ME` with your container name.
+Container names can't have any special characters, or you'll get an error.
+
 ## Standalone
 
 Instantiate a client with your account name, an access key and the container name:

--- a/README.md
+++ b/README.md
@@ -65,21 +65,9 @@ dev:
 You'll have to create the container before you can start uploading files.
 You can do so using Azure CLI, Azure Storage Explorer, or by running:
 
+`bin/rails runner "ActiveStorage::Blob.service.client.tap{|client| client.create_container unless client.get_container_properties.present?}.tap { |client| puts 'done!' if client.get_container_properties.present?}"`
 
-```
-bin/rails runner "
-container_name = 'CONTAINER_NAME_REPLACE_ME'
-require %{azure_blob}
-AzureBlob::Client.new(
-account_name: %{devstoreaccount1},
-access_key: %{Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==},
-host: %{http://127.0.0.1:10000/devstoreaccount1},
-container: container_name)
-.tap{|container| container.create_container unless container.get_container_properties.present?}
-.tap{|container| puts 'done!' if container.get_container_properties.present?}"
-```
-
-Replace `CONTAINER_NAME_REPLACE_ME` with your container name.
+Make sure that `config.active_storage.service = :dev` is set to your azurite configuration.
 Container names can't have any special characters, or you'll get an error.
 
 ## Standalone

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,6 @@ task :test_azurite do |t|
   private_container = AzureBlob::Client.new(account_name:, access_key:, host:, container: ENV["AZURE_PRIVATE_CONTAINER"])
   public_container = AzureBlob::Client.new(account_name:, access_key:, host:, container: ENV["AZURE_PUBLIC_CONTAINER"])
   # public_container.delete_container
-  private_container.delete_container
   private_container.create_container unless private_container.get_container_properties.present?
   public_container.create_container(public_access: true) unless public_container.get_container_properties.present?
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -15,6 +15,7 @@
     sshuttle
     sshpass
     rsync
+    azurite
   ];
 
   languages.ruby.enable = true;

--- a/lib/active_storage/service/azure_blob_service.rb
+++ b/lib/active_storage/service/azure_blob_service.rb
@@ -35,13 +35,14 @@ module ActiveStorage
   class Service::AzureBlobService < Service
     attr_reader :client, :container, :signer
 
-    def initialize(storage_account_name:, storage_access_key: nil, container:, public: false, **options)
+    def initialize(storage_account_name:, storage_access_key: nil, container:, storage_blob_host: nil, public: false, **options)
       @container = container
       @public = public
       @client = AzureBlob::Client.new(
         account_name: storage_account_name,
         access_key: storage_access_key,
         container: container,
+        storage_blob_host: storage_blob_host,
         **options)
     end
 

--- a/lib/active_storage/service/azure_blob_service.rb
+++ b/lib/active_storage/service/azure_blob_service.rb
@@ -35,14 +35,14 @@ module ActiveStorage
   class Service::AzureBlobService < Service
     attr_reader :client, :container, :signer
 
-    def initialize(storage_account_name:, storage_access_key: nil, container:, host: nil, public: false, **options)
+    def initialize(storage_account_name:, storage_access_key: nil, container:, storage_blob_host: nil, public: false, **options)
       @container = container
       @public = public
       @client = AzureBlob::Client.new(
         account_name: storage_account_name,
         access_key: storage_access_key,
         container: container,
-        host:,
+        host: storage_blob_host,
         **options)
     end
 

--- a/lib/active_storage/service/azure_blob_service.rb
+++ b/lib/active_storage/service/azure_blob_service.rb
@@ -35,14 +35,14 @@ module ActiveStorage
   class Service::AzureBlobService < Service
     attr_reader :client, :container, :signer
 
-    def initialize(storage_account_name:, storage_access_key: nil, container:, storage_blob_host: nil, public: false, **options)
+    def initialize(storage_account_name:, storage_access_key: nil, container:, host: nil, public: false, **options)
       @container = container
       @public = public
       @client = AzureBlob::Client.new(
         account_name: storage_account_name,
         access_key: storage_access_key,
         container: container,
-        storage_blob_host: storage_blob_host,
+        host:,
         **options)
     end
 

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -191,8 +191,12 @@ module AzureBlob
     # Calls to {Create Container}[https://learn.microsoft.com/en-us/rest/api/storageservices/create-container]
     def create_container(options = {})
       uri = generate_uri(container)
+      headers = {}
+      headers[:"x-ms-blob-public-access"] = "blob" if options[:public_access]
+      headers[:"x-ms-blob-public-access"] = options[:public_access] if ["container","blob"].include?(options[:public_access])
+
       uri.query = URI.encode_www_form(restype: "container")
-      response = Http.new(uri, signer:).put
+      response = Http.new(uri, headers, signer:).put
     end
 
     # Delete the container

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -15,9 +15,10 @@ module AzureBlob
   # AzureBlob Client class. You interact with the Azure Blob api
   # through an instance of this class.
   class Client
-    def initialize(account_name:, access_key: nil, principal_id: nil, container:, **options)
+    def initialize(account_name:, access_key: nil, principal_id: nil, container:, storage_blob_host: nil, **options)
       @account_name = account_name
       @container = container
+      @storage_blob_host = storage_blob_host
       @cloud_regions = options[:cloud_regions]&.to_sym || :global
 
       no_access_key = access_key.nil? || access_key&.empty?
@@ -356,7 +357,7 @@ module AzureBlob
     end
 
     def host
-      @host ||= "https://#{account_name}.blob.#{CLOUD_REGIONS_SUFFIX[cloud_regions]}"
+      @host ||= @storage_blob_host || "https://#{account_name}.blob.#{CLOUD_REGIONS_SUFFIX[cloud_regions]}"
     end
 
     attr_reader :account_name, :signer, :container, :http, :cloud_regions

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -15,10 +15,10 @@ module AzureBlob
   # AzureBlob Client class. You interact with the Azure Blob api
   # through an instance of this class.
   class Client
-    def initialize(account_name:, access_key: nil, principal_id: nil, container:, storage_blob_host: nil, **options)
+    def initialize(account_name:, access_key: nil, principal_id: nil, container:, host: nil, **options)
       @account_name = account_name
       @container = container
-      @storage_blob_host = storage_blob_host
+      @host = host
       @cloud_regions = options[:cloud_regions]&.to_sym || :global
 
       no_access_key = access_key.nil? || access_key&.empty?
@@ -30,8 +30,8 @@ module AzureBlob
         )
       end
       @signer = using_managed_identities ?
-        AzureBlob::EntraIdSigner.new(account_name:, host:, principal_id:) :
-        AzureBlob::SharedKeySigner.new(account_name:, access_key:)
+        AzureBlob::EntraIdSigner.new(account_name:, host: self.host, principal_id:) :
+        AzureBlob::SharedKeySigner.new(account_name:, access_key:, host: self.host)
     end
 
     # Create a blob of type block. Will automatically split the the blob in multiple block and send the blob in pieces (blocks) if the blob is too big.
@@ -357,7 +357,7 @@ module AzureBlob
     end
 
     def host
-      @host ||= @storage_blob_host || "https://#{account_name}.blob.#{CLOUD_REGIONS_SUFFIX[cloud_regions]}"
+      @host ||= "https://#{account_name}.blob.#{CLOUD_REGIONS_SUFFIX[cloud_regions]}"
     end
 
     attr_reader :account_name, :signer, :container, :http, :cloud_regions

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -104,11 +104,13 @@ class TestClient < TestCase
   end
 
   def test_upload_raise_on_invalid_checksum_blob
+    skip if ENV["TESTING_AZURITE"]
     checksum = OpenSSL::Digest::MD5.base64digest(content + "a")
     assert_raises(AzureBlob::Http::IntegrityError) { client.create_block_blob(key, content, content_md5: checksum) }
   end
 
   def test_upload_raise_on_invalid_checksum_block
+    skip if ENV["TESTING_AZURITE"]
     checksum = OpenSSL::Digest::MD5.base64digest(content + "a")
     assert_raises(AzureBlob::Http::IntegrityError) { client.put_blob_block(key, 0, content, content_md5: checksum) }
   end

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -13,11 +13,13 @@ class TestClient < TestCase
     @access_key = ENV["AZURE_ACCESS_KEY"]
     @container = ENV["AZURE_PRIVATE_CONTAINER"]
     @principal_id = ENV["AZURE_PRINCIPAL_ID"]
+    @host = ENV["STORAGE_BLOB_HOST"]
     @client = AzureBlob::Client.new(
       account_name: @account_name,
       access_key: @access_key,
       container: @container,
       principal_id: @principal_id,
+      host: @host,
     )
     @key = "test client##{name}"
     @content = "Some random content #{Random.rand(200)}"
@@ -340,6 +342,7 @@ class TestClient < TestCase
       access_key: @access_key,
       container: Random.alphanumeric(20).tr("0-9", "").downcase,
       principal_id: @principal_id,
+      host: @host,
     )
     container = client.get_container_properties
     refute container.present?

--- a/test/rails/service/azure_blob_service_test.rb
+++ b/test/rails/service/azure_blob_service_test.rb
@@ -21,7 +21,8 @@ class ActiveStorage::Service::AzureBlobServiceTest < ActiveSupport::TestCase
     @service.headers_for_direct_upload(key, checksum: checksum, content_type: content_type, filename: ActiveStorage::Filename.new("test.txt")).each do |k, v|
       request.add_field k, v
     end
-    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.port == 443) do |http|
       http.request request
     end
 
@@ -42,7 +43,7 @@ class ActiveStorage::Service::AzureBlobServiceTest < ActiveSupport::TestCase
     @service.headers_for_direct_upload(key, checksum: checksum, content_type: "text/plain", filename: ActiveStorage::Filename.new("test.txt"), disposition: :attachment).each do |k, v|
       request.add_field k, v
     end
-    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.port == 443) do |http|
       http.request request
     end
 

--- a/test/rails/service/configurations.yml
+++ b/test/rails/service/configurations.yml
@@ -3,7 +3,7 @@ DEFAULT: &default
   storage_account_name: <%= ENV["AZURE_ACCOUNT_NAME"] %>
   storage_access_key: <%= ENV["AZURE_ACCESS_KEY"] %>
   principal_id: <%= ENV["AZURE_PRINCIPAL_ID"]%>
-  host: <%= ENV["STORAGE_BLOB_HOST"] %>
+  storage_blob_host: <%= ENV["STORAGE_BLOB_HOST"] %>
 
 azure:
   <<: *default

--- a/test/rails/service/configurations.yml
+++ b/test/rails/service/configurations.yml
@@ -3,6 +3,7 @@ DEFAULT: &default
   storage_account_name: <%= ENV["AZURE_ACCOUNT_NAME"] %>
   storage_access_key: <%= ENV["AZURE_ACCESS_KEY"] %>
   principal_id: <%= ENV["AZURE_PRINCIPAL_ID"]%>
+  host: <%= ENV["STORAGE_BLOB_HOST"] %>
 
 azure:
   <<: *default

--- a/test/rails/service/shared_service_tests.rb
+++ b/test/rails/service/shared_service_tests.rb
@@ -30,6 +30,7 @@ module ActiveStorage::Service::SharedServiceTests
     end
 
     test "uploading without integrity" do
+      skip if ENV["TESTING_AZURITE"]
       key  = SecureRandom.base58(24)
       data = "Something else entirely!"
 
@@ -39,7 +40,7 @@ module ActiveStorage::Service::SharedServiceTests
 
       assert_not @service.exist?(key)
     ensure
-      @service.delete key
+      @service.delete key unless ENV["TESTING_AZURITE"]
     end
 
     test "uploading with integrity and multiple keys" do

--- a/test/support/azurite.rb
+++ b/test/support/azurite.rb
@@ -1,0 +1,20 @@
+require "open3"
+require "shellwords"
+
+class Azurite
+  def initialize(verbose: false)
+    @verbose = verbose
+    stdin, stdout, @wait_thread = Open3.popen2e("azurite")
+    stdout.each do |line|
+      break if line.include?("Azurite Blob service is successfully listening at http://127.0.0.1:10000")
+    end
+  end
+
+  def kill
+    Process.kill("INT", wait_thread.pid)
+  end
+
+  private
+
+  attr_reader :wait_thread
+end


### PR DESCRIPTION
Adding support for configuration `storage_blob_host`, which makes the gem compatible with azurite. I've adopted this variable name given it is the same supported by [azure-storage-blob](https://github.com/Azure/azure-storage-ruby/tree/master/blob)

I was able to runtime test this in my application's environment, using azure-blob gem. To test this with azurite, the following needs to be done:
* Run azurite locally. A quick way to have it running locally with docker is:
`docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0 --blobPort 10000`
If you need more configuration options you can check azurite's official documentation [here](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio,blob-storage)
* Using [Microsoft Azure Storage Explorer](https://azure.microsoft.com/en-us/products/storage/storage-explorer#Download-4), connect to your local azurite and create your container
* In your application, add new parameter configuration to your relevant config/storage.yaml configuration: `storage_blob_host: http://127.0.0.1:10000/devstoreaccount1`
* Run application 