### PR TITLE
Initialize signer lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Allow lazy loading the signer
+
 ## [0.5.4] 2024-11-18
 
 - Allow creating public container

--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ client.delete_blob(path)
 
 For the full list of methods: https://www.rubydoc.info/gems/azure-blob/AzureBlob/Client
 
+## options
+
+### Lazy loading
+
+The client is configured to raise an error early for missing credentials, causing it to crash before becoming healthy. This behavior can sometimes be undesirable, such as during assets precompilation.
+
+To enable lazy loading and ignore missing credentials, set the `lazy` option:
+
+`AzureBlob::Client.new(account_name: nil, access_key: nil, container: nil, lazy: true)`
+
+or add `lazy: true` to your `config/storage.yml` for Active Storage.
+
+
 ## Contributing
 
 ### Dev environment

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -23,6 +23,7 @@ module AzureBlob
       @access_key = access_key
       @principal_id = principal_id
       @use_managed_identities = options[:use_managed_identities]
+      signer unless options[:lazy]
     end
 
     # Create a blob of type block. Will automatically split the the blob in multiple block and send the blob in pieces (blocks) if the blob is too big.

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -66,6 +66,18 @@ class TestClient < TestCase
     )
   end
 
+  def test_lazy_loading_doesnt_raise_before_querying
+    client = AzureBlob::Client.new(
+      account_name: @account_name,
+      container: @container,
+      lazy: true,
+    )
+
+    assert_raises(AzureBlob::Error) do
+      client.create_block_blob(key, content)
+    end
+  end
+
   def test_single_block_upload
     client.create_block_blob(key, content)
 


### PR DESCRIPTION
By initializing the signer lazily, only when used the first time, the check for missing `secret_key` and `principal_id` is also postponed until an actual API call to Azure is made.

This makes it possible to load the Rails environment without setting the Azure Storage credentials in environments that do not need to connect to Azure. For example, a build step that precompiles assets needs to load the environments, but usually does not need Azure Storage. Before this change, one would still have to set some (possibly fake) `secret_key` or `principal_id` in such build step, while with this change those can be omitted in any environment in which no real calls to the Azure API will be made.