### PR TITLE
Add support for additional headers

### DIFF
--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -323,6 +323,7 @@ module AzureBlob
         "Content-Type": options[:content_type],
         "x-ms-blob-content-md5": options[:content_md5],
         "x-ms-blob-content-disposition": options[:content_disposition],
+        **(options[:headers] || {}).map { |k, v| [ :"x-ms-#{k}", v.to_s ] }.to_h
       }
 
       Http.new(uri, headers, signer:, **options.slice(:metadata, :tags)).put(content)
@@ -355,6 +356,7 @@ module AzureBlob
         "Content-Type": options[:content_type],
         "x-ms-blob-content-md5": options[:content_md5],
         "x-ms-blob-content-disposition": options[:content_disposition],
+        **(options[:headers] || {}).map { |k, v| [ :"x-ms-#{k}", v.to_s ] }.to_h
       }
 
       Http.new(uri, headers, signer:, **options.slice(:metadata, :tags)).put(content.read)


### PR DESCRIPTION
Thanks for incredible gem!!

In our app we want the ability to pass additional headers (We have custom ActiveStorage::Service class inherits from `ActiveStorage::Service::AzureBlobService`)

There are many use cases where want to send additional headers for example [Customer Provided Keys](https://azure.microsoft.com/en-us/blog/customer-provided-keys-with-azure-storage-service-encryption/) for Encryption

https://github.com/Azure/azure-storage-ruby/pull/221
https://learn.microsoft.com/en-us/azure/storage/blobs/encryption-customer-provided-keys
https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob


_Change is fairly simple but I can improve this PR further if necessary._