### PR TITLE
Add `blob_exist?` and `container_exist?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
 - Allow lazy loading the signer
+- Add `blob_exist?`
+- Add `container_exist?`
 
 ## [0.5.4] 2024-11-18
 

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -142,13 +142,23 @@ module AzureBlob
     #
     # Calls to {Get Blob Properties}[https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties]
     #
-    # This can be used to see if the blob exist or obtain metadata such as content type, disposition, checksum or Azure custom metadata.
+    # This can be used to obtain metadata such as content type, disposition, checksum or Azure custom metadata.
+    # To check for blob presence, look for `blob_exist?` as `get_blob_properties` raises on missing blob.
     def get_blob_properties(key, options = {})
       uri = generate_uri("#{container}/#{key}")
 
       response = Http.new(uri, signer:).head
 
       Blob.new(response)
+    end
+
+    # Returns a boolean indicating if the blob exists.
+    #
+    # Calls to {Get Blob Properties}[https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties]
+    def blob_exist?(key, options = {})
+      get_blob_properties(key, options).present?
+    rescue AzureBlob::Http::FileNotFoundError
+      false
     end
 
     # Returns the tags associated with a blob
@@ -176,6 +186,13 @@ module AzureBlob
       response = Http.new(uri, signer:, raise_on_error: false).head
 
       Container.new(response)
+    end
+
+    # Returns a boolean indicating if the container exists.
+    #
+    # Calls to {Get Container Properties}[https://learn.microsoft.com/en-us/rest/api/storageservices/get-container-properties]
+    def container_exist?(options = {})
+      get_container_properties(options = {}).present?
     end
 
     # Create the container

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -239,6 +239,14 @@ class TestClient < TestCase
     assert_raises(AzureBlob::Http::FileNotFoundError) { client.get_blob_properties(key) }
   end
 
+  def test_blob_exist?
+    refute client.blob_exist?(key)
+
+    client.create_block_blob(key, content)
+
+    assert client.blob_exist?(key)
+  end
+
   def test_append_blob
     client.create_append_blob(key)
     content.split("", 3).each { |chunk| client.append_blob_block(key, chunk) }
@@ -346,6 +354,19 @@ class TestClient < TestCase
     )
     container = client.get_container_properties
     refute container.present?
+  end
+
+  def test_container_exist?
+    assert client.container_exist?
+
+    client = AzureBlob::Client.new(
+      account_name: @account_name,
+      access_key: @access_key,
+      container: "missingcontainer",
+      principal_id: @principal_id,
+    )
+
+    refute client.container_exist?
   end
 
   def test_create_container


### PR DESCRIPTION
Fixes #9

Add `blob_exist?` and `container_exist?`.

Those method do not raise like `get_blob_properties(...).present?` does and are less verbose.

`get_container_properties` doesn't raise (which is an issue since the api is not consistent), but I added `container_exist?` for consistency. Plus it's shorter!

 