### PR TITLE
Add Copy blob to client and use in compose when composing a new blob from a single blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Add `copy_blob`
+- Update `compose` to use `copy_blob` if 1 source key and blob is <= 256MiB
+
 ## [0.5.6] 2025-01-17
 
 - Fix user delegation key not refreshing (#14)

--- a/lib/active_storage/service/azure_blob_service.rb
+++ b/lib/active_storage/service/azure_blob_service.rb
@@ -124,8 +124,8 @@ module ActiveStorage
       content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
 
       # use copy_blob operation if composing a new blob from a single existing blob
-      # and that single blob is <= 5000 MiB which is the upper limit for copy_blob operation
-      if source_keys.length == 1 && client.get_blob_properties(source_keys[0]).size <= 5000.megabytes
+      # and that single blob is <= 256 MiB which is the upper limit for copy_blob operation
+      if source_keys.length == 1 && client.get_blob_properties(source_keys[0]).size <= 256.megabytes
         client.copy_blob(destination_key, source_keys[0], metadata: custom_metadata)
       else
         client.create_append_blob(

--- a/lib/active_storage/service/azure_blob_service.rb
+++ b/lib/active_storage/service/azure_blob_service.rb
@@ -124,7 +124,8 @@ module ActiveStorage
       content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
 
       # use copy_blob operation if composing a new blob from a single existing blob
-      if source_keys.length == 1
+      # and that single blob is <= 256 MiB which is the upper limit for copy_blob operation
+      if source_keys.length == 1 && client.get_blob_properties(source_keys[0]).size <= 256.megabytes
         client.copy_blob(destination_key, source_keys[0], metadata: custom_metadata)
       else
         client.create_append_blob(

--- a/lib/active_storage/service/azure_blob_service.rb
+++ b/lib/active_storage/service/azure_blob_service.rb
@@ -123,16 +123,21 @@ module ActiveStorage
     def compose(source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
       content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
 
-      client.create_append_blob(
-        destination_key,
-        content_type: content_type,
-        content_disposition: content_disposition,
-        metadata: custom_metadata,
-      )
+      # use copy_blob operation if composing a new blob from a single existing blob
+      if source_keys.length == 1
+        client.copy_blob(destination_key, source_keys[0], metadata: custom_metadata)
+      else
+        client.create_append_blob(
+          destination_key,
+          content_type: content_type,
+          content_disposition: content_disposition,
+          metadata: custom_metadata,
+        )
 
-      source_keys.each do |source_key|
-        stream(source_key) do |chunk|
-          client.append_blob_block(destination_key, chunk)
+        source_keys.each do |source_key|
+          stream(source_key) do |chunk|
+            client.append_blob_block(destination_key, chunk)
+          end
         end
       end
     end

--- a/lib/active_storage/service/azure_blob_service.rb
+++ b/lib/active_storage/service/azure_blob_service.rb
@@ -124,8 +124,8 @@ module ActiveStorage
       content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
 
       # use copy_blob operation if composing a new blob from a single existing blob
-      # and that single blob is <= 256 MiB which is the upper limit for copy_blob operation
-      if source_keys.length == 1 && client.get_blob_properties(source_keys[0]).size <= 256.megabytes
+      # and that single blob is <= 5000 MiB which is the upper limit for copy_blob operation
+      if source_keys.length == 1 && client.get_blob_properties(source_keys[0]).size <= 5000.megabytes
         client.copy_blob(destination_key, source_keys[0], metadata: custom_metadata)
       else
         client.create_append_blob(

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -83,14 +83,14 @@ module AzureBlob
     #
     # Takes a key (path) and a source_key (path).
     #
-    def copy_blob(key, source_key)
+    def copy_blob(key, source_key, options = {})
       uri = generate_uri("#{container}/#{key}")
 
       headers = {
         "x-ms-copy-source": generate_uri("#{container}/#{source_key}").to_s,
       }
 
-      Http.new(uri, headers, signer:).put
+      Http.new(uri, headers, signer:, **options.slice(:metadata, :tags)).put
     end
 
     # Delete a blob

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -79,7 +79,7 @@ module AzureBlob
 
     # Copy a blob
     #
-    # Calls to {Put Blob From URL}[https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url]
+    # Calls to {Copy Blob From URL}[https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url]
     #
     # Takes a key (path) and a source_key (path).
     #

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -79,7 +79,7 @@ module AzureBlob
 
     # Copy a blob
     #
-    # Calls to {Copy Blob From URL}[https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url]
+    # Calls to {Put Blob From URL}[https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob-from-url]
     #
     # Takes a key (path) and a source_key (path).
     #
@@ -87,8 +87,9 @@ module AzureBlob
       uri = generate_uri("#{container}/#{key}")
 
       headers = {
+        "Content-Length": "0",
         "x-ms-copy-source": generate_uri("#{container}/#{source_key}").to_s,
-        "x-ms-requires-sync": "true",
+        "x-ms-blob-type": "BlockBlob",
       }
 
       Http.new(uri, headers, signer:, **options.slice(:metadata, :tags)).put

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -77,6 +77,22 @@ module AzureBlob
       Http.new(uri, headers, signer:).get
     end
 
+    # Copy a blob
+    #
+    # Calls to {Copy Blob}[https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob]
+    #
+    # Takes a key (path) and a source_key (path).
+    #
+    def copy_blob(key, source_key)
+      uri = generate_uri("#{container}/#{key}")
+
+      headers = {
+        "x-ms-copy-source": generate_uri("#{container}/#{source_key}").to_s,
+      }
+
+      Http.new(uri, headers, signer:).put
+    end
+
     # Delete a blob
     #
     # Calls to {Delete Blob}[https://learn.microsoft.com/en-us/rest/api/storageservices/delete-blob]
@@ -202,7 +218,7 @@ module AzureBlob
       uri = generate_uri(container)
       headers = {}
       headers[:"x-ms-blob-public-access"] = "blob" if options[:public_access]
-      headers[:"x-ms-blob-public-access"] = options[:public_access] if ["container","blob"].include?(options[:public_access])
+      headers[:"x-ms-blob-public-access"] = options[:public_access] if [ "container", "blob" ].include?(options[:public_access])
 
       uri.query = URI.encode_www_form(restype: "container")
       response = Http.new(uri, headers, signer:).put

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -79,7 +79,7 @@ module AzureBlob
 
     # Copy a blob
     #
-    # Calls to {Copy Blob}[https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob]
+    # Calls to {Copy Blob From URL}[https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url]
     #
     # Takes a key (path) and a source_key (path).
     #
@@ -88,6 +88,7 @@ module AzureBlob
 
       headers = {
         "x-ms-copy-source": generate_uri("#{container}/#{source_key}").to_s,
+        "x-ms-requires-sync": "true",
       }
 
       Http.new(uri, headers, signer:, **options.slice(:metadata, :tags)).put

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -79,7 +79,7 @@ module AzureBlob
 
     # Copy a blob
     #
-    # Calls to {Put Blob From URL}[https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob-from-url]
+    # Calls to {Put Blob From URL}[https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url]
     #
     # Takes a key (path) and a source_key (path).
     #
@@ -89,9 +89,8 @@ module AzureBlob
       source_uri = signed_uri(source_key, permissions: "r", expiry: Time.at(Time.now.to_i + 300).utc.iso8601)
 
       headers = {
-        "Content-Length": 0,
         "x-ms-copy-source": source_uri.to_s,
-        "x-ms-blob-type": "BlockBlob",
+        "x-ms-requires-sync": "true",
       }
 
       Http.new(uri, headers, signer:, **options.slice(:metadata, :tags)).put

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -87,7 +87,7 @@ module AzureBlob
       uri = generate_uri("#{container}/#{key}")
 
       headers = {
-        "Content-Length": "0",
+        "Content-Length": 0,
         "x-ms-copy-source": generate_uri("#{container}/#{source_key}").to_s,
         "x-ms-blob-type": "BlockBlob",
       }

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -86,9 +86,11 @@ module AzureBlob
     def copy_blob(key, source_key, options = {})
       uri = generate_uri("#{container}/#{key}")
 
+      source_uri = signed_uri(source_key, permissions: "r", expiry: Time.at(Time.now.to_i + 300).utc.iso8601)
+
       headers = {
         "Content-Length": 0,
-        "x-ms-copy-source": generate_uri("#{container}/#{source_key}").to_s,
+        "x-ms-copy-source": source_uri.to_s,
         "x-ms-blob-type": "BlockBlob",
       }
 

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -175,6 +175,17 @@ class TestClient < TestCase
     assert_raises(AzureBlob::Http::FileNotFoundError) { client.get_blob(key) }
   end
 
+  def test_copy
+    client.create_block_blob(key, content)
+    assert_equal content, client.get_blob(key)
+
+    copy_key = "#{key}_copy"
+
+    client.copy_blob(copy_key, key)
+
+    assert_equal content, client.get_blob(copy_key)
+  end
+
   def test_delete
     client.create_block_blob(key, content)
     assert_equal content, client.get_blob(key)

--- a/test/rails/service/azure_blob_service_test.rb
+++ b/test/rails/service/azure_blob_service_test.rb
@@ -116,4 +116,25 @@ class ActiveStorage::Service::AzureBlobServiceTest < ActiveSupport::TestCase
   ensure
     @service.delete(key)
   end
+
+  test "composing a blob from one source blob" do
+    key  = SecureRandom.base58(24)
+    data = "Something else entirely!"
+
+    Tempfile.open do |file|
+      file.write(data)
+      file.rewind
+      @service.upload(key, file)
+    end
+
+    assert_equal data, @service.download(key)
+
+    copy_key = SecureRandom.base58(24)
+    @service.compose([ key ], copy_key)
+
+    assert_equal data, @service.download(copy_key)
+  ensure
+    @service.delete key
+    @service.delete copy_key
+  end
 end

--- a/test/rails/service/shared_service_tests.rb
+++ b/test/rails/service/shared_service_tests.rb
@@ -158,5 +158,24 @@ module ActiveStorage::Service::SharedServiceTests
 
       assert_equal "Together", @service.download(destination_key)
     end
+
+    test "compose from single blob" do
+      keys = [ SecureRandom.base58(24) ]
+      data = %w[Together]
+      keys.zip(data).each do |key, data|
+        @service.upload(
+          key,
+          StringIO.new(data),
+          checksum: Digest::MD5.base64digest(data),
+          disposition: :attachment,
+          filename: ActiveStorage::Filename.new("test.html"),
+          content_type: "text/html",
+        )
+      end
+      destination_key = SecureRandom.base58(24)
+      @service.compose(keys, destination_key)
+
+      assert_equal "Together", @service.download(destination_key)
+    end
   end
 end


### PR DESCRIPTION
In our app we wanted to reduce data handling in `compose` when only a single source blob is provided. To reduce data handling, I have added in support for [`copy-blob`](https://learn.microsoft.com/en-us/rest/api/storageservices/copy-blob).

Now `compose` has slightly different behaviour. When a single source key is specified, the `compose` method will instead use `copy-blob` operation, otherwise the existing behaviour remains.

