### PR TITLE
Add support for copying blobs between containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add support for copying blobs across containers (#24)
+
 ## [0.5.7.1] 2025-04-22
 
 - Fixed a bug when reusing the account name in the container name. #22


### PR DESCRIPTION
  Fixes #23
 # Add support for copying blobs between containers

  Enhances the `copy_blob` method to accept a `source_client` parameter, allowing blobs
  to be copied between different containers.

  ## Example usage
  ```ruby
  client.copy_blob(destination_key, source_key, source_client: source_client)

  # Original functionality is preserved
  client.copy_blob(destination_key, source_key)
```