### PR TITLE
Fix URI unescape deprecation

### DIFF
--- a/lib/azure_blob/canonicalized_resource.rb
+++ b/lib/azure_blob/canonicalized_resource.rb
@@ -5,7 +5,7 @@ module AzureBlob
     def initialize(uri, account_name, service_name: nil, url_safe: true)
       # This next line is needed because CanonicalizedResource
       # need to be escaped for auhthorization headers, but not SAS tokens
-      path = url_safe ? uri.path : URI::DEFAULT_PARSER.unescape(uri.path)
+      path = url_safe ? uri.path : URI::RFC2396_PARSER.unescape(uri.path)
       resource = "/#{account_name}#{path.empty? ? "/" : path}"
       resource = "/#{service_name}#{resource}" if service_name
       params = CGI.parse(uri.query.to_s)


### PR DESCRIPTION
## Summary
- use RFC2396 parser when unescaping canonicalized resource paths


