### PR TITLE
Add RuboCop to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,16 @@ env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: RuboCop
+        run: bundle exec rubocop
   deploy-infrastructure:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/test')


### PR DESCRIPTION
## Summary
- remove standalone lint workflow
- include RuboCop job in the main test workflow
