### PR TITLE
Fix parallel test file collisions

### DIFF
--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -194,7 +194,8 @@ module AzureBlob
     #
     # Returns a hash of the blob's tags.
     def get_blob_tags(key)
-      uri = generate_uri("#{container}/#{key}?comp=tags")
+      uri = generate_uri("#{container}/#{key}")
+      uri.query = URI.encode_www_form(comp: "tags")
       response = Http.new(uri, signer:).get
 
       Tags.from_response(response).to_h
@@ -246,7 +247,8 @@ module AzureBlob
     #
     # Example: +generate_uri("#{container}/#{key}")+
     def generate_uri(path)
-      URI.parse(URI::RFC2396_PARSER.escape(File.join(host, path)))
+      encoded = path.split("/").map { |segment| CGI.escape(segment) }.join("/")
+      URI.parse([host.chomp("/"), encoded].join("/"))
     end
 
     # Returns an SAS signed URI

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -248,7 +248,7 @@ module AzureBlob
     # Example: +generate_uri("#{container}/#{key}")+
     def generate_uri(path)
       encoded = path.split("/").map { |segment| CGI.escape(segment) }.join("/")
-      URI.parse([host.chomp("/"), encoded].join("/"))
+      URI.parse([ host.chomp("/"), encoded ].join("/"))
     end
 
     # Returns an SAS signed URI

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -22,7 +22,8 @@ class TestClient < TestCase
       principal_id: @principal_id,
       host: @host,
     )
-    @key = "test client##{name}"
+    @uid = SecureRandom.uuid
+    @key = "test-client-#{name}-#{@uid}"
     @content = "Some random content #{Random.rand(200)}"
   end
 
@@ -197,9 +198,9 @@ class TestClient < TestCase
   end
 
   def test_delete_prefix
-    prefix = "#{name}_prefix"
+    prefix = "#{name}_prefix_#{@uid}"
     keys = 4.times.map do |i|
-      key = "#{prefix}/#{name}_#{i}"
+      key = "#{prefix}/#{i}"
       client.create_block_blob(key, content)
       key
     end
@@ -212,7 +213,7 @@ class TestClient < TestCase
   end
 
   def test_list_prefix
-    prefix = "#{name}_prefix"
+    prefix = "#{name}_prefix_#{@uid}"
     @key = "#{prefix}/#{key}"
     client.create_block_blob(key, content)
 
@@ -222,9 +223,9 @@ class TestClient < TestCase
   end
 
   def test_list_blobs_with_pages
-    prefix = "#{name}_prefix"
+    prefix = "#{name}_prefix_#{@uid}"
     keys = 4.times.map do |i|
-      key = "#{prefix}/#{name}_#{i}"
+      key = "#{prefix}/#{i}"
       client.create_block_blob(key, content)
       key
     end

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -23,7 +23,7 @@ class TestClient < TestCase
       host: @host,
     )
     @uid = SecureRandom.uuid
-    @key = "test-client-#{name}-#{@uid}"
+    @key = "test-client-?-#{name}-#{@uid}" # ? in key to test proper escaping
     @content = "Some random content #{Random.rand(200)}"
   end
 

--- a/test/support/app_service_vpn.rb
+++ b/test/support/app_service_vpn.rb
@@ -74,7 +74,7 @@ class AppServiceVpn
     puts "Extracting MSI endpoint info..."
     endpoint = nil
     header = nil
-    Net::SSH.start(HOST, username, password:, port:, encryption: 'aes256-ctr', hmac: 'hmac-sha1-96', auth_methods: ['password']) do |ssh|
+    Net::SSH.start(HOST, username, password:, port:, encryption: "aes256-ctr", hmac: "hmac-sha1-96", auth_methods: [ "password" ]) do |ssh|
       endpoint = ssh.exec! [ "bash", "-l", "-c", %(printf "%s" "$IDENTITY_ENDPOINT") ].shelljoin
       header = ssh.exec! [ "bash", "-l", "-c", %(printf "%s" "$IDENTITY_HEADER") ].shelljoin
     end


### PR DESCRIPTION
## Summary
- add a unique ID to the blob key in client tests
- isolate prefix based keys using the unique ID
