### PR TITLE
Fix duplicate CI triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
   push:
     tags:
       - test
-    branches:
-      - '*'
-    pull_request:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
- avoid duplicate workflow runs on branches

## Testing
- `OFFLINE_TESTS_ONLY=1 bundle exec m test/client/test_client.rb` *(fails: `access_key` cannot be empty)*