### PR TITLE
Add debug output and offline CI support

### DIFF
--- a/lib/azure_blob/http.rb
+++ b/lib/azure_blob/http.rb
@@ -116,6 +116,7 @@ module AzureBlob
 
     def raise_error
       return unless raise_on_error
+      warn "[AzureBlob] HTTP #{response.code} body: #{response.body}" if ENV["CI"]
       raise error_from_response.new(body: @response.body, status: @response.code&.to_i)
     end
 

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -9,6 +9,7 @@ class TestClient < TestCase
   EXPIRATION = 120
 
   def setup
+    skip if offline?
     @account_name = ENV["AZURE_ACCOUNT_NAME"]
     @access_key = ENV["AZURE_ACCESS_KEY"]
     @container = ENV["AZURE_PRIVATE_CONTAINER"]

--- a/test/client/test_helper.rb
+++ b/test/client/test_helper.rb
@@ -17,4 +17,8 @@ class TestCase < Minitest::Test
   def using_shared_key
     !(ENV["AZURE_ACCESS_KEY"].nil? || ENV["AZURE_ACCESS_KEY"].empty?)
   end
+
+  def offline?
+    ENV.key?("OFFLINE_TESTS_ONLY")
+  end
 end

--- a/test/client/test_user_delegation_key.rb
+++ b/test/client/test_user_delegation_key.rb
@@ -5,7 +5,7 @@ require_relative "test_helper"
 class TestUserDelegationKey < TestCase
   attr_reader :delegation_key, :account_name, :principal_id, :signer, :host
   def setup
-    skip if using_shared_key
+    skip if using_shared_key || offline?
     @account_name = ENV["AZURE_ACCOUNT_NAME"]
     @principal_id = ENV["AZURE_PRINCIPAL_ID"]
     @host = "https://#{account_name}.blob.core.windows.net"

--- a/test/rails/controllers/blobs/redirect_controller_test.rb
+++ b/test/rails/controllers/blobs/redirect_controller_test.rb
@@ -4,6 +4,7 @@ require "rails/test_helper"
 require "rails/database/setup"
 
 class ActiveStorage::Blobs::RedirectControllerWithOpenRedirectTest < ActionDispatch::IntegrationTest
+  setup { skip if offline? }
   test "showing existing blob stored in azure" do
     with_raise_on_open_redirects(:azure) do
       blob = create_file_blob filename: "racecar.jpg", service_name: :azure

--- a/test/rails/controllers/direct_uploads_controller_test.rb
+++ b/test/rails/controllers/direct_uploads_controller_test.rb
@@ -6,6 +6,7 @@ require "rails/database/setup"
 
 class ActiveStorage::AzureBlobDirectUploadsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    skip if offline?
     @config = SERVICE_CONFIGURATIONS[:azure]
     ActiveStorage::Blob.service = ActiveStorage::Service.configure(:azure, SERVICE_CONFIGURATIONS)
   end

--- a/test/rails/controllers/representations/redirect_controller_test.rb
+++ b/test/rails/controllers/representations/redirect_controller_test.rb
@@ -4,6 +4,7 @@ require "rails/test_helper"
 require "rails/database/setup"
 
 class ActiveStorage::Representations::RedirectControllerWithOpenRedirectTest < ActionDispatch::IntegrationTest
+  setup { skip if offline? }
   test "showing existing variant stored in azure" do
     with_raise_on_open_redirects(:azure) do
       blob = create_file_blob filename: "racecar.jpg", service_name: :azure

--- a/test/rails/service/azure_blob_public_service_test.rb
+++ b/test/rails/service/azure_blob_public_service_test.rb
@@ -9,6 +9,7 @@ class ActiveStorage::Service::AzureBlobPublicServiceTest < ActiveSupport::TestCa
   include ActiveStorage::Service::SharedServiceTests
 
   setup do
+    skip if offline?
     @config = SERVICE_CONFIGURATIONS[:azure_public]
   end
 

--- a/test/rails/service/azure_blob_service_test.rb
+++ b/test/rails/service/azure_blob_service_test.rb
@@ -6,6 +6,8 @@ require "uri"
 class ActiveStorage::Service::AzureBlobServiceTest < ActiveSupport::TestCase
   SERVICE = ActiveStorage::Service.configure(:azure, SERVICE_CONFIGURATIONS)
 
+  setup { skip if offline? }
+
   include ActiveStorage::Service::SharedServiceTests
 
   test "direct upload with content type" do

--- a/test/rails/service/shared_service_tests.rb
+++ b/test/rails/service/shared_service_tests.rb
@@ -10,6 +10,7 @@ module ActiveStorage::Service::SharedServiceTests
 
   included do
     setup do
+      skip if offline?
       @key = SecureRandom.base58(24)
       @service = self.class.const_get(:SERVICE)
       @service.upload @key, StringIO.new(FIXTURE_DATA)

--- a/test/rails/test_helper.rb
+++ b/test/rails/test_helper.rb
@@ -3,6 +3,10 @@
 require "debug"
 require "action_view"
 require "action_view/helpers"
+
+def offline?
+  ENV.key?("OFFLINE_TESTS_ONLY")
+end
 ENV["RAILS_ENV"] ||= "test"
 require_relative "dummy/config/environment.rb"
 


### PR DESCRIPTION
## Summary
- add basic error debug output for CI
- provide `offline?` helpers for tests
- skip network tests in offline mode

## Testing
- `OFFLINE_TESTS_ONLY=true AZURE_ACCOUNT_NAME=foo AZURE_ACCESS_KEY=abc AZURE_PRIVATE_CONTAINER=priv AZURE_PUBLIC_CONTAINER=publ bundle exec rake test`
- `OFFLINE_TESTS_ONLY=true AZURE_ACCOUNT_NAME=foo AZURE_ACCESS_KEY=abc AZURE_PRIVATE_CONTAINER=priv AZURE_PUBLIC_CONTAINER=publ bundle exec m test/client/test_identity_token.rb`