### PR TITLE
Allow manual dispatch of azure app service/vm tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - test
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -29,7 +30,7 @@ jobs:
         run: bundle exec rubocop
   deploy-infrastructure:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/test')
+    if: startsWith(github.ref, 'refs/tags/test') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-terraform


### PR DESCRIPTION
## Summary
- enable workflow_dispatch on test workflow
- allow deploy step to run on manual dispatch

## Testing
- `bundle exec m test/client/test_client.rb:35` *(fails: Failed to open TCP connection to proxy:8080)*