### PR TITLE
Fix URI encoding for special characters in blob names

### DIFF
--- a/lib/azure_blob/blob_list.rb
+++ b/lib/azure_blob/blob_list.rb
@@ -61,7 +61,7 @@ module AzureBlob
     def current_page
       document
         .get_elements("//EnumerationResults/Blobs/Blob/Name")
-        .map { |element| element.get_text.to_s }
+        .map { |element| element.text }
     end
 
     def fetch

--- a/lib/azure_blob/client.rb
+++ b/lib/azure_blob/client.rb
@@ -10,6 +10,7 @@ require_relative "shared_key_signer"
 require_relative "entra_id_signer"
 require "time"
 require "base64"
+require "stringio"
 
 module AzureBlob
   # AzureBlob Client class. You interact with the Azure Blob api
@@ -248,8 +249,12 @@ module AzureBlob
     #
     # Example: +generate_uri("#{container}/#{key}")+
     def generate_uri(path)
-      encoded = path.split("/").map { |segment| CGI.escape(segment) }.join("/")
-      URI.parse([ host.chomp("/"), encoded ].join("/"))
+      # https://github.com/Azure/azure-storage-ruby/blob/master/common/lib/azure/storage/common/service/storage_service.rb#L191-L201
+      encoded_path = CGI.escape(path.encode("UTF-8"))
+      encoded_path = encoded_path.gsub(/%2F/, "/")
+      encoded_path = encoded_path.gsub(/%5C/, "/")
+      encoded_path = encoded_path.gsub(/\+/, "%20")
+      URI.parse(File.join(host, encoded_path))
     end
 
     # Returns an SAS signed URI

--- a/test/client/test_client.rb
+++ b/test/client/test_client.rb
@@ -23,7 +23,7 @@ class TestClient < TestCase
       host: @host,
     )
     @uid = SecureRandom.uuid
-    @key = "test-client-?-#{name}-#{@uid}" # ? in key to test proper escaping
+    @key = "test-client-#{name}-#{@uid} ?#&<>\"'%+/\\" # Special chars to test proper escaping
     @content = "Some random content #{Random.rand(200)}"
   end
 
@@ -219,7 +219,9 @@ class TestClient < TestCase
 
     blobs = client.list_blobs(prefix: prefix).to_a
 
-    assert_match_content [ key ], blobs
+    # Account for backslash to forward slash conversion in our encoding
+    expected_key = key.gsub(/\\/, "/")
+    assert_match_content [ expected_key ], blobs
   end
 
   def test_list_blobs_with_pages

--- a/test/client/test_generate_uri.rb
+++ b/test/client/test_generate_uri.rb
@@ -1,0 +1,54 @@
+require_relative "test_helper"
+
+class TestGenerateUri < TestCase
+  def setup
+    @client = AzureBlob::Client.new(
+      account_name: "testaccount",
+      access_key: "ACCESS-KEY",
+      container: "test-container"
+    )
+  end
+
+  def test_generate_uri_with_special_characters
+    test_cases = {
+      "container/simple.txt" => "https://testaccount.blob.core.windows.net/container/simple.txt",
+      "container/path/to/file.txt" => "https://testaccount.blob.core.windows.net/container/path/to/file.txt",
+      "container\\backslash\\path.txt" => "https://testaccount.blob.core.windows.net/container/backslash/path.txt",
+      "container/file with spaces.txt" => "https://testaccount.blob.core.windows.net/container/file%20with%20spaces.txt",
+      "container/file+with+plus.txt" => "https://testaccount.blob.core.windows.net/container/file%2Bwith%2Bplus.txt",
+      "container/file?with?question.txt" => "https://testaccount.blob.core.windows.net/container/file%3Fwith%3Fquestion.txt",
+      "container/file#with#hash.txt" => "https://testaccount.blob.core.windows.net/container/file%23with%23hash.txt",
+      "container/file&with&ampersand.txt" => "https://testaccount.blob.core.windows.net/container/file%26with%26ampersand.txt",
+      "container/file%with%percent.txt" => "https://testaccount.blob.core.windows.net/container/file%25with%25percent.txt",
+      "container/file<with>brackets.txt" => "https://testaccount.blob.core.windows.net/container/file%3Cwith%3Ebrackets.txt",
+      "container/file\"with\"quotes.txt" => "https://testaccount.blob.core.windows.net/container/file%22with%22quotes.txt",
+      "container/file'with'apostrophe.txt" => "https://testaccount.blob.core.windows.net/container/file%27with%27apostrophe.txt",
+      "container/test ?#&<>\"'%+/\\.txt" => "https://testaccount.blob.core.windows.net/container/test%20%3F%23%26%3C%3E%22%27%25%2B//.txt",
+    }
+
+    test_cases.each do |input, expected|
+      uri = @client.send(:generate_uri, input)
+      assert_equal expected, uri.to_s, "Failed for input: #{input}"
+    end
+  end
+
+  def test_generate_uri_preserves_container_name
+    containers = [
+      "mycontainer",
+      "my-container",
+      "container123",
+      "my-container-123",
+    ]
+
+    containers.each do |container|
+      path = "#{container}/file.txt"
+      uri = @client.send(:generate_uri, path)
+      assert uri.to_s.include?("/#{container}/"), "Container name was incorrectly encoded: #{container}"
+    end
+  end
+
+  def test_generate_uri_with_utf8_characters
+    uri = @client.send(:generate_uri, "test-container/文件名.txt")
+    assert_equal "https://testaccount.blob.core.windows.net/test-container/%E6%96%87%E4%BB%B6%E5%90%8D.txt", uri.to_s
+  end
+end


### PR DESCRIPTION
## Summary
- Fix URI encoding for special characters in blob names to prevent crashes when flushing test containers
- Update generate_uri method to match Azure Storage Ruby gem's exact encoding approach
- Fix HTML entity decoding issues in blob name listing

## Changes
- Updated `generate_uri` method in `client.rb` to use `CGI.escape` with proper post-processing
- Fixed HTML entity decoding in `blob_list.rb` by using `element.text` instead of `element.get_text.to_s`
- Added comprehensive tests for special character handling in blob names
- Updated existing tests to account for backslash-to-forward-slash conversion


Fixes #35